### PR TITLE
Update ServerConnection.swift

### DIFF
--- a/tunnel_server/ServerConnection.swift
+++ b/tunnel_server/ServerConnection.swift
@@ -114,7 +114,7 @@ class ServerConnection: Connection, StreamDelegate {
 	// MARK: NSStreamDelegate
 
 	/// Handle an event on a stream.
-	func stream(aStream:Stream, handleEvent eventCode: Stream.Event) {
+	func stream(_ aStream: Stream, handle eventCode: Stream.Event) {
 		switch aStream {
 
 			case writeStream!:


### PR DESCRIPTION
fix: update NSStreamDelegate function code to Swift 5 this problem caused the ServerConnection stream's delegate never be called, so the server cannot communicate with the network outside